### PR TITLE
eit_print: avoid calling printf two times

### DIFF
--- a/dvb/si/eit_print.h
+++ b/dvb/si/eit_print.h
@@ -98,32 +98,31 @@ static inline void eit_print(uint8_t *p_eit,
 
     while ((p_event = eit_get_event(p_eit, j)) != NULL) {
         j++;
-        char start_str[24], duration_str[10];
+        char start_str[24];
         int duration, hour, min, sec;
         time_t start_ts;
 
         start_ts = dvb_time_format_UTC(eitn_get_start_time(p_event), NULL, start_str);
 
         dvb_time_decode_bcd(eitn_get_duration_bcd(p_event), &duration, &hour, &min, &sec);
-        sprintf(duration_str, "%02d:%02d:%02d", hour, min, sec);
 
         switch (i_print_type) {
         case PRINT_XML:
             pf_print(print_opaque, "<EVENT id=\"%u\" start_time=\"%ld\" start_time_dec=\"%s\""
-                                   " duration=\"%u\" duration_dec=\"%s\""
+                                   " duration=\"%u\" duration_dec=\"%u:%02u:%02u\""
                                    " running=\"%d\" free_CA=\"%d\">",
                      eitn_get_event_id(p_event),
                      start_ts, start_str,
-                     duration, duration_str,
+                     duration, hour, min, sec,
                      eitn_get_running(p_event),
                      eitn_get_ca(p_event)
                     );
             break;
         default:
-            pf_print(print_opaque, "  * EVENT id=%u start_time=%ld start_time_dec=\"%s\" duration=%u duration_dec=%s running=%d free_CA=%d",
+            pf_print(print_opaque, "  * EVENT id=%u start_time=%ld start_time_dec=\"%s\" duration=%u duration_dec=%u:%02u:%02u running=%d free_CA=%d",
                      eitn_get_event_id(p_event),
                      start_ts, start_str,
-                     duration, duration_str,
+                     duration, hour, min, sec,
                      eitn_get_running(p_event),
                      eitn_get_ca(p_event)
                     );


### PR DESCRIPTION
The first printf also has this problem:
if hour, min or sec is >= 100 we can overflow duration_str

In file included from ./bitstream/dvb/si_print.h:35:0,
                 from dvb_print_si.c:42:
dvb_print_si.c: In function ‘handle_section’:
./bitstream/dvb/si/eit_print.h:108:42: warning: ‘%02d’ directive writing between 2 and 3 bytes into a region of size between 2 and 4 [-Wformat-overflow=]
         sprintf(duration_str, "%02d:%02d:%02d", hour, min, sec);
                                          ^~~~
./bitstream/dvb/si/eit_print.h:108:31: note: directive argument in the range [0, 165]
         sprintf(duration_str, "%02d:%02d:%02d", hour, min, sec);
                               ^~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862:0,
                 from dvb_print_si.c:33:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:33:10: note: ‘__builtin___sprintf_chk’ output between 9 and 12 bytes into a destination of size 10
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~