### PR TITLE
desc 48: Update 'desc48_get_provider' to match 'desc48_get_service'

### DIFF
--- a/dvb/si/desc_48.h
+++ b/dvb/si/desc_48.h
@@ -72,10 +72,10 @@ static inline void desc48_set_provider(uint8_t *p_desc,
     memcpy(p + 1, p_provider, i_length);
 }
 
-static inline const uint8_t *desc48_get_provider(const uint8_t *p_desc,
+static inline uint8_t *desc48_get_provider(const uint8_t *p_desc,
                                                  uint8_t *pi_length)
 {
-    const uint8_t *p = p_desc + DESC48_HEADER_SIZE;
+    uint8_t *p = p_desc + DESC48_HEADER_SIZE;
     *pi_length = p[0];
     return p + 1;
 }


### PR DESCRIPTION
desc48_get_service does not return 'const' but 'desc48_get_provider' does. So change _get_provider to drop 'const'