### PR TITLE
Prevent segfault in SDT printing if section count is wrong

### DIFF
--- a/dvb/si/sdt_print.h
+++ b/dvb/si/sdt_print.h
@@ -73,6 +73,9 @@ static inline void sdt_table_print(uint8_t **pp_sections,
         uint8_t *p_service;
         int j = 0;
 
+       if (p_section == NULL)
+           break;
+
         while ((p_service = sdt_get_service(p_section, j)) != NULL) {
             j++;
             switch (i_print_type) {


### PR DESCRIPTION
A crash is seen on transponder is 11538V on 28.2e when SDT is being printed.