### PR TITLE
atsc/si/desc_81.h: fix descriptor name in print

### DIFF
--- a/atsc/si/desc_81.h
+++ b/atsc/si/desc_81.h
@@ -233,7 +233,7 @@ static inline void desc81_print(const uint8_t *p_desc, f_print pf_print,
         break;
     default:
         pf_print(opaque,
-                 "    - desc 81 ac-3"
+                 "    - desc 81 ac3"
                  " sample_rate=\"0x%02x\""
                  " bsid=\"0x%02x\""
                  " bit_rate=\"0x%02x\""


### PR DESCRIPTION
Change descriptor name from ac-3 to ac3 to be consistent with the other descriptors.